### PR TITLE
Make sure autossh doesn't get stuck when there are temporary forwarding issues

### DIFF
--- a/autossh-tunnel.service.template
+++ b/autossh-tunnel.service.template
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Environment="AUTOSSH_GATETIME=0"
-ExecStart=/usr/bin/autossh -M 0 -o "ServerAliveInterval 90" -o "ServerAliveCountMax 3" -NR ${SSH_TUNNEL_REMOTE_PORT}:localhost:22 ${SSH_TUNNEL_CONNECTION}
+ExecStart=/usr/bin/autossh -M 0 -o "ServerAliveInterval 90" -o "ServerAliveCountMax 3" -o "ExitOnForwardFailure=yes" -NR ${SSH_TUNNEL_REMOTE_PORT}:localhost:22 ${SSH_TUNNEL_CONNECTION}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Sometimes the remote has the port occupied (esp. when disconnect happens via a power cutoff).
https://serverfault.com/questions/512978/autossh-failed-recreating-a-tunnel-due-to-different-timing/563401#563401

Logs without the change:
```
autossh[13835]: Warning: remote port forwarding failed for listen port XXX
```
Autossh never connects until it's restarted. Which requires access to the machine

Logs with change:
```
autossh[14398]: starting ssh (count 2)
autossh[14398]: ssh child pid is 14431
autossh[14431]: Error: remote port forwarding failed for listen port XXX
autossh[14398]: ssh exited with error status 255; restarting ssh

autossh[14398]: starting ssh (count 3)
autossh[14398]: ssh child pid is 14432
autossh[14432]: Error: remote port forwarding failed for listen port XXX
```
After some time when remote port is freed, the service restarts and autossh connection is established